### PR TITLE
File separator has to be escaped for Windows environmnent

### DIFF
--- a/src/main/groovy/com/aoe/gebspockreports/GebReportUtils.groovy
+++ b/src/main/groovy/com/aoe/gebspockreports/GebReportUtils.groovy
@@ -19,6 +19,8 @@ import com.aoe.gebspockreports.report.GebReport
 import com.google.gson.GsonBuilder
 import geb.ConfigurationLoader
 
+import java.util.regex.Matcher
+
 /**
  * Utility class to access relevant geb report info more easily.
  */
@@ -77,7 +79,7 @@ class GebReportUtils {
     static String createSpecLabelFromPath(String specPath) {
         String label = specPath
         label = removeReportDirFromPath(label)
-        label.replaceAll(File.separator, ".")
+        label.replaceAll(Matcher.quoteReplacement(File.separator), ".")
     }
 
     /**


### PR DESCRIPTION
Otherwise following failure is observed:
```
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
 ^

at com.aoe.gebspockreports.GebReportUtils.createSpecLabelFromPath(GebReportUtils.groovy:80)
at com.aoe.gebspockreports.GebReportingListener.onReport(GebReportingListener.groovy:40)
```