### PR TITLE
Add source code to spec-template.

### DIFF
--- a/src/main/resources/templates/spec-template.html
+++ b/src/main/resources/templates/spec-template.html
@@ -147,6 +147,12 @@ writeIssuesOrSees(utils.specAnnotation(data, spock.lang.See), 'See')
         </td>
         <td class="block-text">
             <p class="block-text">$block.text</p>
+            <% if (block.sourceCode) {
+                %><pre><%
+                block.sourceCode.each { out << it << System.getProperty("line.separator") }
+                %></pre><%
+            }
+            %>
         </td>
     </tr>
     <% } %>


### PR DESCRIPTION
The existing behavior is to display "When: ----" or similar for the block text.
This remains when com.athaydes.spockframework.report.showCodeBlocks is false.
When it is true, the code associated with the block is pasted.

CSS is not added yet. A further improvement would be to remove the blocks
entirely when showCodeBlocks is false.