### PR TITLE
Add Spock 2.0 support (WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.3.0-RC1
+
+* Add support for:
+  * spock-core 2.0-M2
+  * spock-reports 2.0-RC2
+  * Groovy 3
+
 ## v0.2.6
 
 * Replace whitespace with underscore in Geb artifact files (#25)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add dependencies.
 
 ```groovy
 dependencies {
-    testCompile 'com.aoe:geb-spock-reports:0.2.6'
+    testCompile 'com.aoe:geb-spock-reports:0.3.0-RC1'
     
     // required spock libraries
     testCompile "org.spockframework:spock-core:2.0-M2-groovy-3.0"
@@ -54,7 +54,7 @@ dependencies {
 
 | geb-spock-reports | spock-reports | spock-core  | Groovy   |
 |-------------------|---------------|-------------|----------|
-| 0.3.0             | 2.0-RC2       | 2.0-M2      | 3.0.*    |
+| 0.3.0-RC1         | 2.0-RC2       | 2.0-M2      | 3.0.*    |
 | 0.2.6             | 1.6.0         | 1.1         | 2.4.*    |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ dependencies {
     testCompile 'com.aoe:geb-spock-reports:0.2.6'
     
     // required spock libraries
-    testCompile "org.spockframework:spock-core:1.1-groovy-2.4-rc-4"
-    testCompile ("com.athaydes:spock-reports:1.6.0") { transitive = false }
+    testCompile "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    testCompile ("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
     
     // required geb libraries
-    testCompile "org.gebish:geb-spock:2.2"
+    testCompile "org.gebish:geb-spock:3.4"
     
     // you may also need selenium support
-    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.9.1"
-    testCompile "org.seleniumhq.selenium:selenium-support:3.9.1"
+    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
+    testCompile "org.seleniumhq.selenium:selenium-support:3.11.0"
     
     // recommended for logging
-    testCompile 'org.slf4j:slf4j-api:1.7.13'
-    testCompile 'org.slf4j:slf4j-simple:1.7.13'
+    testCompile 'org.slf4j:slf4j-api:1.7.30'
+    testCompile 'org.slf4j:slf4j-simple:1.7.30'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ dependencies {
 }
 ```
 
+## Compatibility
+
+| geb-spock-reports | spock-reports | spock-core  | Groovy   |
+|-------------------|---------------|-------------|----------|
+| 0.3.0             | 2.0-RC2       | 2.0-M2      | 3.0.*    |
+| 0.2.6             | 1.6.0         | 1.1         | 2.4.*    |
+
 ## Configuration
 
 ### Configure Geb

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.12'
-    compile 'org.gebish:geb-core:2.2'
+    compile 'org.codehaus.groovy:groovy-all:3.0.3'
+    compile 'org.gebish:geb-core:3.4'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,4 @@
-plugins {
-    id 'nebula.project' version '5.1.2'
-    id 'nebula.release' version '8.0.3'
-    id 'nebula.nebula-bintray' version '4.0.2'
-    id 'com.jfrog.artifactory' version '4.7.5'
-}
+plugins { }
 
 group 'com.aoe'
 apply plugin: 'groovy'
@@ -17,32 +12,4 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.12'
     compile 'org.gebish:geb-core:2.2'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
-}
-
-contacts {
-    'tilman.ginzel@aoe.com' {
-        moniker 'Tilman Ginzel'
-        github 'tilmanginzel'
-    }
-}
-
-def projectUrl = 'https://github.com/AOEpeople/geb-spock-reports'
-
-bintray {
-    if (project.hasProperty('bintrayUser')) {
-        user = project.property('bintrayUser')
-        key = project.property('bintrayKey')
-    }
-
-    dryRun = false
-    publish = false
-    pkg {
-        repo = 'libraries'
-        userOrg = 'aoepeople'
-        websiteUrl = projectUrl
-        issueTrackerUrl = "$projectUrl/issues"
-        vcsUrl = "$projectUrl/.git"
-        licenses = ['Apache-2.0']
-        labels = ['spock', 'geb', 'spock-reports', 'testing', 'reports']
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
-plugins { }
+plugins {
+    id "com.jfrog.bintray" version "1.8.5"
+    id "maven-publish"
+    id "java-library"
+}
 
 group 'com.aoe'
+version = '0.3.0-RC1'
 apply plugin: 'groovy'
 
 repositories {
@@ -13,3 +18,69 @@ dependencies {
     compile 'org.gebish:geb-core:3.4'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
 }
+
+def projectUrl = 'https://github.com/AOEpeople/geb-spock-reports'
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+
+    dryRun = false
+    publish = false
+    publications = ['maven']
+
+    pkg {
+        repo = 'libraries'
+        name = 'geb-spock-reports'
+        userOrg = 'aoepeople'
+        websiteUrl = projectUrl
+        githubRepo = projectUrl
+        githubReleaseNotesFile = "$projectUrl/blob/master/README.md"
+        issueTrackerUrl = "$projectUrl/issues"
+        vcsUrl = "$projectUrl/.git"
+        licenses = ['Apache-2.0']
+        labels = ['spock', 'geb', 'spock-reports', 'testing', 'reports']
+        version {
+            name = project.version
+            released = new Date()
+            vcsTag = "v${project.version}"
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+            groupId = 'com.aoe'
+            artifactId = 'geb-spock-reports'
+            version = project.version
+            pom {
+                name = 'geb-spock-reports'
+                description = 'Integrates Geb screenshots into the spock-reports library '
+                url = 'https://github.com/AOEpeople/geb-spock-reports'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'tilmanginzel'
+                        name = 'Tilman Ginzel'
+                        email = 'tilman.ginzel@aoe.com'
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+bintrayUpload.dependsOn build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.energizedwork.webdriver-binaries" version "1.4"
+    id "eu.leontebbens.gradle.chromedriver-updater" version "1.6.2"
 }
 apply plugin: 'groovy'
 apply plugin: 'application'
@@ -21,17 +21,22 @@ dependencies {
     testCompile 'org.slf4j:slf4j-api:1.7.13'
     testCompile 'org.slf4j:slf4j-simple:1.7.13'
 
-    testCompile "org.seleniumhq.selenium:selenium-chrome-driver:3.9.1"
-    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.9.1"
-    testCompile "org.seleniumhq.selenium:selenium-support:3.9.1"
+    testCompile "org.seleniumhq.selenium:selenium-chrome-driver:3.11.0"
+    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
+    testCompile "org.seleniumhq.selenium:selenium-support:3.11.0"
 }
 
-webdriverBinaries {
-    chromedriver '2.36'
+chromedriver {
+    majorVersion = "83"
 }
 
 test {
+    dependsOn updateChromedriver
+
     testLogging {
         showStandardStreams = true
     }
+
+    useJUnitPlatform()
+    systemProperty 'webdriver.chrome.driver', "${updateChromedriver.driverLocation}"
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -13,13 +13,13 @@ dependencies {
     testCompile rootProject
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile "org.spockframework:spock-core:1.1-groovy-2.4-rc-4"
+    testCompile "org.spockframework:spock-core:2.0-M2-groovy-3.0"
 
-    testCompile "org.gebish:geb-spock:2.2"
-    testCompile ("com.athaydes:spock-reports:1.6.0") { transitive = false }
+    testCompile "org.gebish:geb-spock:3.4"
+    testCompile("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
 
-    testCompile 'org.slf4j:slf4j-api:1.7.13'
-    testCompile 'org.slf4j:slf4j-simple:1.7.13'
+    testCompile 'org.slf4j:slf4j-api:1.7.30'
+    testCompile 'org.slf4j:slf4j-simple:1.7.30'
 
     testCompile "org.seleniumhq.selenium:selenium-chrome-driver:3.11.0"
     testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"

--- a/src/main/resources/templates/spec-template.html
+++ b/src/main/resources/templates/spec-template.html
@@ -168,7 +168,7 @@ def gebArtifacts = gebFeatureReport?.artifacts
         <span class="feature-name feature-name-$cssClass">$name</span>
 
         <%
-        def ignoreReason = description.getAnnotation(spock.lang.Ignore)?.value()
+        def ignoreReason = utils.featureAnnotation(delegate, spock.lang.Ignore)?.value()
         if (ignoreReason) { %>
         <p class="ignore-reason">$ignoreReason</p>
         <% } %>
@@ -189,8 +189,8 @@ def gebArtifacts = gebFeatureReport?.artifacts
 
     <!-- print name and issue/see annotation-->
     <%
-    writeIssuesOrSees(description.getAnnotation(spock.lang.Issue), 'Issues')
-    writeIssuesOrSees(description.getAnnotation(spock.lang.See), 'See')
+    writeIssuesOrSees(utils.featureAnnotation(delegate, spock.lang.Issue), 'Issues')
+    writeIssuesOrSees(utils.featureAnnotation(delegate, spock.lang.See), 'See')
     %>
 
     <!-- print given, when, then, ... blocks -->


### PR DESCRIPTION
This pull request updates dependencies and adds support for:
- Spock 2.0-M2
- spock-reports 2.0-RC2
- Groovy 3
- Geb-Spock 3.4

Open todos:
- [x] Show compatibility matrix to README
- [x] Add gradle plugin to either create or publish jar files for Bintray release
- [ ] Bump and release version 0.3.0