### PR TITLE
Update spock reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0-RC2
+* Add support for
+  * spock-core 2.1
+  * spock-reports 2.3.0
+
 ## v0.3.0-RC1
 
 * Add support for:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 geb-spock-reports is a library to integrate [Geb](http://gebish.org/) screenshots into [spock-reports](https://github.com/renatoathaydes/spock-reports).
 
-Report Summary            |  Specification Results
-:-------------------------:|:-------------------------:
-[![](./sample/screenshots/geb-spock-reports_summary-template-thumb.jpg)](./sample/screenshots/geb-spock-reports_summary-template.png) | [![](./sample/screenshots/geb-spock-reports_spec-template-thumb.jpg)](./sample/screenshots/geb-spock-reports_spec-template-thumb.jpg)
+|                                                                                                                        Report Summary | Specification Results                                                                                                                 |
+|--------------------------------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------|
+| [![](./sample/screenshots/geb-spock-reports_summary-template-thumb.jpg)](./sample/screenshots/geb-spock-reports_summary-template.png) | [![](./sample/screenshots/geb-spock-reports_spec-template-thumb.jpg)](./sample/screenshots/geb-spock-reports_spec-template-thumb.jpg) |
 
 * [Compatibility](#compatibility)
 * [Usage](#usage)
@@ -20,10 +20,11 @@ Report Summary            |  Specification Results
 
 ## Compatibility
 
-| geb-spock-reports | spock-reports | spock-core  | Groovy   | JUnit |
-|-------------------|---------------|-------------|----------|-------|
-| 0.3.0-RC1         | 2.0-RC2       | 2.0-M2      | 3.0.*    | 5     |
-| 0.2.6             | 1.6.0         | 1.1         | 2.4.*    | 4     |
+| geb-spock-reports | spock-reports | spock-core | Groovy | JUnit |
+|-------------------|---------------|------------|--------|-------|
+| 0.3.0-RC2         | 2.1.0         | 2.1        | 3.0.*  | 5     |
+| 0.3.0-RC1         | 2.0-RC2       | 2.0-M2     | 3.0.*  | 5     |
+| 0.2.6             | 1.6.0         | 1.1        | 2.4.*  | 4     |
 
 ## Usage
 
@@ -39,23 +40,23 @@ Add dependencies.
 
 ```groovy
 dependencies {
-    testImplementation 'com.aoe:geb-spock-reports:0.3.0-RC1'
+    testImplementation 'com.aoe:geb-spock-reports:0.3.0-RC2'
 
     // required spock libraries
-    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    testImplementation "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
-    testImplementation ("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
+    testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0'
+    testImplementation('com.athaydes:spock-reports:2.3.0-groovy-3.0') { transitive = false }
     
     // required geb libraries
-    testImplementation "org.gebish:geb-spock:3.4"
+    testImplementation 'org.gebish:geb-spock:5.1'
     
     // you may also need selenium support
-    testImplementation "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
-    testImplementation "org.seleniumhq.selenium:selenium-support:3.11.0"
+    testImplementation 'org.seleniumhq.selenium:selenium-chrome-driver:4.3.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.3.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-support:4.3.0'
     
     // recommended for logging
-    testImplementation 'org.slf4j:slf4j-api:1.7.30'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
+    testImplementation 'org.slf4j:slf4j-api:1.7.36'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 }
 ```
 
@@ -105,7 +106,7 @@ com.athaydes.spockframework.report.template.TemplateReportCreator.summaryFileNam
 com.athaydes.spockframework.report.projectName=Sample Project Name
 
 # Set the version of the project under test so it can be displayed in the report or leave empty and it will be ignored
-com.athaydes.spockframework.report.projectVersion=0.3.0-RC1
+com.athaydes.spockframework.report.projectVersion=0.3.0-RC2
 ```
 
 See the [spock-reports documentation](https://github.com/renatoathaydes/spock-reports#customizing-the-reports) for further configuration.

--- a/README.md
+++ b/README.md
@@ -39,23 +39,23 @@ Add dependencies.
 
 ```groovy
 dependencies {
-    testCompile 'com.aoe:geb-spock-reports:0.3.0-RC1'
+    testImplementation 'com.aoe:geb-spock-reports:0.3.0-RC1'
 
     // required spock libraries
-    testCompile "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    testCompile "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
-    testCompile ("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    testImplementation "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
+    testImplementation ("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
     
     // required geb libraries
-    testCompile "org.gebish:geb-spock:3.4"
+    testImplementation "org.gebish:geb-spock:3.4"
     
     // you may also need selenium support
-    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
-    testCompile "org.seleniumhq.selenium:selenium-support:3.11.0"
+    testImplementation "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
+    testImplementation "org.seleniumhq.selenium:selenium-support:3.11.0"
     
     // recommended for logging
-    testCompile 'org.slf4j:slf4j-api:1.7.30'
-    testCompile 'org.slf4j:slf4j-simple:1.7.30'
+    testImplementation 'org.slf4j:slf4j-api:1.7.30'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:3.0.3'
-    compile 'org.gebish:geb-core:3.4'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.3'
+    implementation 'org.gebish:geb-core:3.4'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
 }
 
 def projectUrl = 'https://github.com/AOEpeople/geb-spock-reports'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.aoe'
-version = '0.3.0-RC1'
+version = '0.3.0-RC2'
 apply plugin: 'groovy'
 
 repositories {
@@ -13,9 +13,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:3.0.3'
-    implementation 'org.gebish:geb-core:3.4'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.11'
+    implementation 'org.gebish:geb-core:5.1'
+    implementation 'com.google.code.gson:gson:2.9.0'
 }
 
 def projectUrl = 'https://github.com/AOEpeople/geb-spock-reports'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,20 +9,20 @@ repositories {
 }
 
 dependencies {
-    testCompile rootProject
+    testImplementation rootProject
 
-    testCompile "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    testCompile "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    testImplementation "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
 
-    testCompile "org.gebish:geb-spock:3.4"
-    testCompile("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
+    testImplementation "org.gebish:geb-spock:3.4"
+    testImplementation("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
 
-    testCompile 'org.slf4j:slf4j-api:1.7.30'
-    testCompile 'org.slf4j:slf4j-simple:1.7.30'
+    testImplementation 'org.slf4j:slf4j-api:1.7.30'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 
-    testCompile "org.seleniumhq.selenium:selenium-chrome-driver:3.11.0"
-    testCompile "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
-    testCompile "org.seleniumhq.selenium:selenium-support:3.11.0"
+    testImplementation "org.seleniumhq.selenium:selenium-chrome-driver:3.11.0"
+    testImplementation "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
+    testImplementation "org.seleniumhq.selenium:selenium-support:3.11.0"
 }
 
 chromedriver {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,3 @@
-plugins {
-    id "eu.leontebbens.gradle.chromedriver-updater" version "1.6.2"
-}
 apply plugin: 'groovy'
 apply plugin: 'application'
 
@@ -10,6 +7,8 @@ repositories {
 
 dependencies {
     testImplementation rootProject
+
+    testImplementation 'org.codehaus.groovy:groovy-astbuilder:3.0.3'
 
     testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
     testImplementation "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
@@ -23,19 +22,14 @@ dependencies {
     testImplementation "org.seleniumhq.selenium:selenium-chrome-driver:3.11.0"
     testImplementation "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
     testImplementation "org.seleniumhq.selenium:selenium-support:3.11.0"
-}
 
-chromedriver {
-    majorVersion = "83"
+    testImplementation 'io.github.bonigarcia:webdrivermanager:5.2.1'
 }
 
 test {
-    dependsOn updateChromedriver
-
     testLogging {
         showStandardStreams = true
     }
 
     useJUnitPlatform()
-    systemProperty 'webdriver.chrome.driver', "${updateChromedriver.driverLocation}"
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,20 +8,17 @@ repositories {
 dependencies {
     testImplementation rootProject
 
-    testImplementation 'org.codehaus.groovy:groovy-astbuilder:3.0.3'
+    testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0'
 
-    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
-    testImplementation "org.spockframework:spock-junit4:2.0-M2-groovy-3.0"
+    testImplementation 'org.gebish:geb-spock:5.1'
+    testImplementation('com.athaydes:spock-reports:2.3.0-groovy-3.0') { transitive = false }
 
-    testImplementation "org.gebish:geb-spock:3.4"
-    testImplementation("com.athaydes:spock-reports:2.0-RC2") { transitive = false }
+    testImplementation 'org.slf4j:slf4j-api:1.7.36'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 
-    testImplementation 'org.slf4j:slf4j-api:1.7.30'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
-
-    testImplementation "org.seleniumhq.selenium:selenium-chrome-driver:3.11.0"
-    testImplementation "org.seleniumhq.selenium:selenium-firefox-driver:3.11.0"
-    testImplementation "org.seleniumhq.selenium:selenium-support:3.11.0"
+    testImplementation 'org.seleniumhq.selenium:selenium-chrome-driver:4.3.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.3.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-support:4.3.0'
 
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.2.1'
 }

--- a/sample/src/test/resources/GebConfig.groovy
+++ b/sample/src/test/resources/GebConfig.groovy
@@ -1,7 +1,20 @@
 import com.aoe.gebspockreports.GebReportingListener
+import io.github.bonigarcia.wdm.WebDriverManager
+import org.openqa.selenium.Dimension
 import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
 
 reportingListener = new GebReportingListener()
 reportsDir = 'build/geb-spock-reports'
 
-driver = { new ChromeDriver() }
+driver = {
+    WebDriverManager.chromedriver().setup()
+    ChromeOptions chromeOptions = new ChromeOptions()
+    chromeOptions.setHeadless(true)
+
+    Dimension dimension = new Dimension(1920, 1080)
+    ChromeDriver chromeDriver = new ChromeDriver(chromeOptions)
+    chromeDriver.manage().window().setSize(dimension)
+
+    return chromeDriver
+}

--- a/sample/src/test/resources/META-INF/services/com.athaydes.spockframework.report.IReportCreator.properties
+++ b/sample/src/test/resources/META-INF/services/com.athaydes.spockframework.report.IReportCreator.properties
@@ -16,4 +16,4 @@ com.athaydes.spockframework.report.template.TemplateReportCreator.summaryFileNam
 com.athaydes.spockframework.report.projectName=Sample Project Name
 
 # Set the version of the project under test so it can be displayed in the report
-com.athaydes.spockframework.report.projectVersion=0.3.0-RC1
+com.athaydes.spockframework.report.projectVersion=0.3.0-RC2

--- a/src/main/resources/templates/spec-template.html
+++ b/src/main/resources/templates/spec-template.html
@@ -65,11 +65,11 @@ def writeStackTrace = { error, index, featureName ->
     </div>
 <% }
 
-def writeReportInfo = { reportInfo ->
-    if (reportInfo) { %>
+def writeExtraInfo = { extraInfo ->
+    if (extraInfo) { %>
         <h3>Report Info:</h3>
         <ul>
-        <% reportInfo.each { info -> %>
+        <% extraInfo.each { info -> %>
             <li>$info</li>
         <% } %>
         </ul> <%
@@ -161,6 +161,7 @@ def cssClass = isIgnored ? 'ignored' : (isError ? 'error' : (isFailure ? 'failur
 featureCount += isIgnored ? 0 : 1
 def gebFeatureReport = specReport?.findFeatureByNumberAndName(featureCount, name)
 def gebArtifacts = gebFeatureReport?.artifacts
+def feature = delegate
 %>
 
 <div class="feature feature-$cssClass">
@@ -178,11 +179,11 @@ def gebArtifacts = gebFeatureReport?.artifacts
     <%
     if (!isIgnored) {
         if (utils.isUnrolled(delegate)) {
-            writeReportInfo(utils.nextSpecExtraInfo(data))
-        } else {
-            (1..iterations.size()).each {
-                writeReportInfo(utils.nextSpecExtraInfo(data))
+            iterations.each { iter ->
+                writeExtraInfo( utils.nextSpecExtraInfo( data, feature, iter.info ) )
             }
+        } else {
+            writeExtraInfo( utils.nextSpecExtraInfo( data, feature ) )
         }
     }
     %>


### PR DESCRIPTION
A breaking change has been introduced in spock-report in [v2.3.0-groovy-3.0](https://github.com/renatoathaydes/spock-reports/commit/d59834e3917725f70c63871d86975702b9b496ab) and this requires a small refactor in `src/main/resources/templates/spec-template.html`.

Additionally, update gradle to v7.4.2 and update all dependencies to their latest versions.

WebDriverManager is used to handle driver download and setup in sample project because `chromedriver-updater` is not yet updated to work with the gradle v7.